### PR TITLE
feat: Create sample default GHA workflow

### DIFF
--- a/workflow-templates/print-env-data.properties.json
+++ b/workflow-templates/print-env-data.properties.json
@@ -1,0 +1,9 @@
+{
+    "name": "Print Shipyard env data",
+    "description": "Auth into your Shipyard org and fetch Shipyard/Cypress env vars",
+    "iconName": "octicon project-roadmap",
+    "categories": [
+        "continuous-integration",
+        "continuous-delivery"
+    ]
+}

--- a/workflow-templates/print-env-data.yml
+++ b/workflow-templates/print-env-data.yml
@@ -1,0 +1,21 @@
+name: Print Shipyard env data
+on: [push]
+
+jobs:
+  print-env-data:
+    runs-on: ubuntu-latest
+    name: Fetch Shipyard Vars
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Integrate Shipyard
+        uses: shipyard/shipyard-action@1.0.0
+        with:
+          api-token: ${{ secrets.SHIPYARD_API_TOKEN }}
+          timeout-minutes: "10"
+      - name: Print env data
+        run: |
+          export CYPRESS_BASE_URL=${SHIPYARD_ENVIRONMENT_URL}
+          export CYPRESS_BYPASS_TOKEN=${SHIPYARD_BYPASS_TOKEN}
+          env | grep -e SHIPYARD -e CYPRESS
+        shell: bash


### PR DESCRIPTION
This takes the existing GHA workflow we have in starter repos and suggests it as a default for all repos belonging to the SY org